### PR TITLE
Fix cooldown packet behaviour on 1.21.2+ and missing combat-mode check

### DIFF
--- a/api/src/main/java/com/github/sirblobman/plugin/cooldown/api/listener/CooldownListener.java
+++ b/api/src/main/java/com/github/sirblobman/plugin/cooldown/api/listener/CooldownListener.java
@@ -348,6 +348,11 @@ public abstract class CooldownListener extends PluginListener<ConfigurablePlugin
                 continue;
             }
 
+            if (cooldown.checkCombatMode(player)) {
+                printDebug("Player has combat mode mismatch, skipping.");
+                continue;
+            }
+
             int amount = cooldown.getAmount();
             if (amount > 1) {
                 int used = cooldownData.getActionCount(cooldown);

--- a/api/src/main/java/com/github/sirblobman/plugin/cooldown/api/task/PacketCooldownTask.java
+++ b/api/src/main/java/com/github/sirblobman/plugin/cooldown/api/task/PacketCooldownTask.java
@@ -4,10 +4,9 @@ import org.jetbrains.annotations.NotNull;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import com.github.sirblobman.api.folia.details.EntityTaskDetails;
-import com.github.sirblobman.api.nms.MultiVersionHandler;
-import com.github.sirblobman.api.nms.PlayerHandler;
 import com.github.sirblobman.plugin.cooldown.api.CooldownsX;
 
 public final class PacketCooldownTask extends EntityTaskDetails<Player> {
@@ -18,7 +17,6 @@ public final class PacketCooldownTask extends EntityTaskDetails<Player> {
     public PacketCooldownTask(@NotNull CooldownsX plugin, @NotNull Player entity, @NotNull Material material,
                               int ticks) {
         super(plugin.getPlugin(), entity);
-        setDelay(1L);
 
         this.plugin = plugin;
         this.material = material;
@@ -34,22 +32,22 @@ public final class PacketCooldownTask extends EntityTaskDetails<Player> {
 
         int ticks = getTicks();
         Material material = getMaterial();
-        PlayerHandler playerHandler = getPlayerHandler();
-        playerHandler.sendCooldownPacket(player, material, ticks);
+
+        // Use ItemStack variant - Paper reads the item's use_cooldown component
+        // (cooldown_group) and applies cooldown to the correct group.
+        // For 1.21.2+ items like ender_pearl this routes through the new cooldown
+        // group system; for older items it falls back to per-material cooldown.
+        try {
+            ItemStack stack = new ItemStack(material);
+            player.setCooldown(stack, ticks);
+        } catch (Throwable t) {
+            // Fallback for older API
+            player.setCooldown(material, ticks);
+        }
     }
 
     private @NotNull CooldownsX getCooldownsX() {
         return this.plugin;
-    }
-
-    private @NotNull MultiVersionHandler getMultiVersionHandler() {
-        CooldownsX plugin = getCooldownsX();
-        return plugin.getMultiVersionHandler();
-    }
-
-    private @NotNull PlayerHandler getPlayerHandler() {
-        MultiVersionHandler multiVersionHandler = getMultiVersionHandler();
-        return multiVersionHandler.getPlayerHandler();
     }
 
     private @NotNull Material getMaterial() {


### PR DESCRIPTION
## Summary

Fixes two issues that together cause visible item cooldowns to flicker/disappear immediately on Minecraft 1.21.2+ (especially noticeable with ender pearls, since they have their own `use_cooldown` component in vanilla), and lets `checkValidCooldowns` add cooldowns even when the player's combat state means the cooldown should not apply.

Reported on Folia 1.21.11 with CooldownsX 6.0.0.252.

## Bug 1 — missing combat-mode check in `checkValidCooldowns`

`checkActiveCooldowns` correctly skips cooldowns whose `combat-mode` does not match the player's current combat state:

```java
if (cooldown.checkCombatMode(player)) {
    printDebug("Player has combat mode mismatch, skipping.");
    continue;
}
```

But `checkValidCooldowns` did not have this check, so when the player triggered an action (e.g. threw an ender pearl) **out of combat** with a cooldown configured as `combat-mode: TRUE`, the plugin would still:

1. Store the cooldown in the player's state
2. Send a packet cooldown for the configured duration

The cooldown could never actually block the use (the next `checkActiveCooldowns` would skip it due to the mismatch), but on modern MC versions the sent packet **overrode the vanilla item cooldown** for the duration of the configured (but never-enforced) cooldown. With ender pearls this means the vanilla 1-second `minecraft:ender_pearl` group cooldown gets clobbered, and players can spam pearls.

### Repro

Config:

```yaml
enderPearlCombat:
  cooldown: 10
  cooldown-type: INTERACT_ITEM
  material: [ENDER_PEARL]
  packet-cooldown: true
  combat-mode: "TRUE"
```

Out of combat, the user reported pearls firing rapid-fire with the vanilla cooldown bar flashing for ~200 ms then vanishing. Debug log showed `Added cooldown 'enderPearlCombat'` and `Sent cooldown packet for material Ender Pearl` being emitted on every throw, while `checkActiveCooldowns` (correctly) skipped the cooldown on the next throw due to combat-mode mismatch.

### Fix

Add the same combat-mode check to `checkValidCooldowns` so out-of-combat cooldowns are fully skipped — neither stored nor packeted. Vanilla cooldown is left untouched.

## Bug 2 — legacy NMS packet path on 1.21.2+

`PacketCooldownTask` sent a raw per-item SetCooldown packet via `playerHandler.sendCooldownPacket(player, material, ticks)`. Minecraft 1.21.2 changed the SetCooldown packet to target cooldown-group identifiers (`use_cooldown` component, `cooldown_group: minecraft:ender_pearl`) instead of item types. The legacy per-item packet does not interact with the new system properly — the client briefly shows the cooldown, then the vanilla group-cooldown handler clears it.

Switched to `Player#setCooldown(ItemStack, int)`. On Paper 1.21.2+ this reads the item's `use_cooldown` component and applies the cooldown to the correct group; on older versions it delegates to `setCooldown(Material, int)`. Wrapped in `try/catch` with a `setCooldown(Material, int)` fallback for safety.

Also removed the 1-tick scheduling delay. It was there to wait out the vanilla cooldown so the NMS packet would override it cleanly, but with the Bukkit API path it just creates a visible gap between the vanilla cooldown (applied at tick 0) and the plugin's override (applied at tick 1).

## Test plan

- [x] Out of combat: ender pearl shows the vanilla 1-second cooldown, cannot be spammed
- [x] In combat (`combat-mode: TRUE`): ender pearl shows 10-second cooldown, blocks throws server-side
- [x] Plugin's debug log shows `Player has combat mode mismatch, skipping.` in `checkValidCooldowns` when out of combat
- [x] Behaviour also correct for `CONSUME_ITEM` cooldowns (golden apples) on 1.21.x
- [x] Plugin still builds and runs cleanly

Tested on Folia 1.21.11 with the user reproducing the original bug.